### PR TITLE
Removing own interfaces from the list of nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-srv-discovery</artifactId>
-    <version>0.90.11-3</version>
+    <version>0.90.11-8</version>
     <packaging>jar</packaging>
     <name>Elasticsearch SRV discovery plugin</name>
     <description>The SRV discovery plugin allows to use SRV recrds for unicast discovery.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-srv-discovery</artifactId>
-    <version>0.90.11-1</version>
+    <version>0.90.11-3</version>
     <packaging>jar</packaging>
     <name>Elasticsearch SRV discovery plugin</name>
     <description>The SRV discovery plugin allows to use SRV recrds for unicast discovery.</description>

--- a/src/main/java/org/elasticsearch/discovery/srv/SrvDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/srv/SrvDiscovery.java
@@ -26,7 +26,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
-import org.elasticsearch.cluster.settings.DynamicSettings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.zen.ZenDiscovery;
@@ -35,9 +34,6 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-/**
- *
- */
 public class SrvDiscovery extends ZenDiscovery {
 
     @Inject

--- a/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
@@ -106,6 +106,7 @@ public class SrvUnicastHostsProvider extends AbstractComponent implements Unicas
             }
 
             try {
+                logger.info("Trying to resolve '{}'", host);
                 Resolver resolver = new SimpleResolver(host);
                 if (port > 0) {
                     resolver.setPort(port);
@@ -126,7 +127,10 @@ public class SrvUnicastHostsProvider extends AbstractComponent implements Unicas
             } catch (UnknownHostException e) {
                 logger.info("Could not create resolver. Using default resolver.", e);
             }
+        } else {
+            throw new RuntimeException("Unable to find resolvers");
         }
+        logger.info("Trying to discover hosts with a list of {} resolvers", resolvers.size());
         return parent_resolver;
     }
 
@@ -135,6 +139,7 @@ public class SrvUnicastHostsProvider extends AbstractComponent implements Unicas
     }
 
     public List<DiscoveryNode> buildDynamicNodes() {
+        logger.info("Entering buildDynamicNodes");
         List<DiscoveryNode> discoNodes = Lists.newArrayList();
         if (query == null) {
             logger.error("DNS query must not be null. Please set '{}'", DISCOVERY_SRV_QUERY);
@@ -205,12 +210,18 @@ public class SrvUnicastHostsProvider extends AbstractComponent implements Unicas
         return discoNodes;
     }
 
-    protected Record[] lookupRecords() throws TextParseException {
+    private Record[] lookupRecords() throws TextParseException {
+        logger.info("lookupRecords: trying to find {}", query);
         Lookup lookup = new Lookup(query, Type.SRV);
         if (this.resolver != null) {
             lookup.setResolver(this.resolver);
         }
-        return lookup.run();
+        Record[] records = lookup.run();
+        if(records == null) {
+            records = new Record[]{};
+        }
+        logger.info("lookupRecords found: {}", records);
+        return records;
     }
 
     protected List<DiscoveryNode> parseRecords(List<Record> records) {

--- a/src/main/java/org/elasticsearch/plugin/discovery/SrvDiscoveryPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/discovery/SrvDiscoveryPlugin.java
@@ -33,12 +33,10 @@ public class SrvDiscoveryPlugin extends AbstractPlugin {
         this.settings = settings;
     }
 
-    @Override
     public String name() {
         return "srv-discovery";
     }
 
-    @Override
     public String description() {
         return "SRV Discovery Plugin";
     }

--- a/src/test/org/elasticsearch/discovery/srv/SrvUnicastHostsProviderTest.java
+++ b/src/test/org/elasticsearch/discovery/srv/SrvUnicastHostsProviderTest.java
@@ -1,0 +1,65 @@
+package org.elasticsearch.discovery.srv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.junit.Test;
+import org.xbill.DNS.DClass;
+import org.xbill.DNS.Name;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.SRVRecord;
+import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.Type;
+
+public class SrvUnicastHostsProviderTest {
+
+    @Test
+    public void local_address_returns_true() {
+        SrvUnicastHostsProvider provider = new SrvUnicastHostsProvider(ImmutableSettings.EMPTY, null, null);
+        boolean isLocal = provider.isLocalIP("127.0.0.1");
+        assertTrue(isLocal);
+    }
+
+    @Test
+    public void non_local_address_returns_false() {
+        SrvUnicastHostsProvider provider = new SrvUnicastHostsProvider(ImmutableSettings.EMPTY, null, null);
+        boolean isLocal = provider.isLocalIP("255.255.255.255");
+        assertFalse(isLocal);
+    }
+
+    @Test
+    public void non_local_address_returns_fals123e() {
+        SrvUnicastHostsProvider provider = new SrvUnicastHostsProvider(ImmutableSettings.EMPTY, null, null);
+        Record[] records = new Record[] { getRecord("www.somewhere.com."), getRecord("localhost.") };
+        List<Record> filteredRecords = provider.filterOutOwnRecord(records);
+        assertEquals(filteredRecords.size(), 1);
+    }
+
+    private Record getRecord(String name) {
+        try {
+            Name hostname = new Name(name);
+
+            Name target = new Name(name);
+
+            return new SRVRecord(hostname, Type.SRV, DClass.ANY, 30, 1, 80, target);
+        } catch (TextParseException e) {
+            e.printStackTrace();
+        }
+        throw new RuntimeException();
+    }
+
+    @Test
+    public void isTCP() {
+        SrvUnicastHostsProvider provider = new SrvUnicastHostsProvider(ImmutableSettings.EMPTY, null, null);
+        boolean isTCP = provider.isTCP("tcp");
+        assertTrue(isTCP);
+
+        boolean isUDP = provider.isTCP("udp");
+        assertFalse(isUDP);
+    }
+
+}


### PR DESCRIPTION
This is done to avoid trying to connect to your self
when joining a cluster