### PR TITLE
NSKOPS-177: elasticsearch-srv-discovery plugin for ES 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-srv-discovery</artifactId>
-    <version>0.90.11-8</version>
+    <version>1.7.1</version>
     <packaging>jar</packaging>
     <name>Elasticsearch SRV discovery plugin</name>
     <description>The SRV discovery plugin allows to use SRV recrds for unicast discovery.</description>
@@ -25,7 +25,7 @@
     </scm>
 
     <properties>
-        <elasticsearch.version>0.90.11</elasticsearch.version>
+        <elasticsearch.version>1.7.1</elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -78,6 +78,7 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <!-- Build Debian (.deb) package -->
                 <!-- Documentation: https://github.com/tcurdt/jdeb/blob/master/docs/maven.md -->

--- a/src/deb/control/control
+++ b/src/deb/control/control
@@ -11,4 +11,4 @@ Architecture: all
 Conflicts:
 Replaces:
 Description: [[description]]
-Depends: elasticsearch (= 0.90.11)
+Depends: elasticsearch (= 1.7.1)

--- a/src/main/java/org/elasticsearch/discovery/srv/SrvDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/srv/SrvDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Grant Rodgers
+ * Copyright (c) 2015 GitHub
  *
  *     Permission is hereby granted, free of charge, to any person obtaining
  *     a copy of this software and associated documentation files (the "Software"),
@@ -22,25 +22,31 @@
 
 package org.elasticsearch.discovery.srv;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
+import org.elasticsearch.cluster.settings.DynamicSettings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.ZenDiscovery;
+import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.discovery.zen.ping.ZenPingService;
 import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+/**
+ *
+ */
 public class SrvDiscovery extends ZenDiscovery {
 
     @Inject
     public SrvDiscovery(Settings settings, ClusterName clusterName, ThreadPool threadPool, TransportService transportService,
                         ClusterService clusterService, NodeSettingsService nodeSettingsService, ZenPingService pingService,
-                        DiscoveryNodeService discoveryNodeService, Version version) {
+                        DiscoveryNodeService discoveryNodeService,DiscoverySettings discoverySettings,
+                        ElectMasterService electMasterService, DynamicSettings dynamicSettings) {
         super(settings, clusterName, threadPool, transportService, clusterService, nodeSettingsService,
-                discoveryNodeService, pingService, version);
+                discoveryNodeService, pingService, electMasterService, discoverySettings, dynamicSettings);
     }
 }

--- a/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
@@ -29,6 +29,8 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -41,14 +43,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.discovery.zen.ping.unicast.UnicastHostsProvider;
 import org.elasticsearch.transport.TransportService;
-import org.xbill.DNS.ExtendedResolver;
-import org.xbill.DNS.Lookup;
-import org.xbill.DNS.Record;
-import org.xbill.DNS.Resolver;
-import org.xbill.DNS.SRVRecord;
-import org.xbill.DNS.SimpleResolver;
-import org.xbill.DNS.TextParseException;
-import org.xbill.DNS.Type;
+import org.xbill.DNS.*;
 
 /**
  *


### PR DESCRIPTION
In this PR I propose an elasticsearch-srv discovery plugin compatible with ES 1.7.1. The plugin is based on tradeshift/elasticsearch-srv-discovery v 0.90.11 and is patched github/elasticsearch-srv-discovery v 1.5.1. The plugin was compiled to deb-packet and was tested in the AWS environment in an configuration: 1 consul server and two elasticsearch nodes. A cluster was successfully built.